### PR TITLE
Claude Code profile management

### DIFF
--- a/.claude-profiles
+++ b/.claude-profiles
@@ -138,7 +138,7 @@ function cc-init-profiles() {
 
     if [[ ! -d "$dir" ]]; then
       mkdir -p "$dir/skills"
-      echo '{}' > "$dir/settings.json"
+      echo '{"cleanupPeriodDays": 180}' > "$dir/settings.json"
       echo "  ✅ Created $dir"
     else
       # Ensure skills dir exists


### PR DESCRIPTION
## Summary
- Claude Code profile switching system: separate settings, skills, and history for Elicit, Personal, and SocioTechnica contexts
- Symlink-based profile isolation (`~/.claude` → `~/.claude-{profile}`)
- Process detection and graceful shutdown when switching profiles
- Starship prompt integration showing active profile icon and PR numbers
- Session retention set to 6 months (180 days) across all profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)