### PR TITLE
Add missing autoload for add-zsh-hook

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -50,6 +50,8 @@ source ~/.claude-profiles
 # Starship prompt (config at ~/.config/starship.toml)
 eval "$(starship init zsh)"
 
+autoload -Uz add-zsh-hook
+
 # Async PR number cache using zsh-async
 source /opt/homebrew/opt/zsh-async/share/zsh/site-functions/async
 async_init


### PR DESCRIPTION
## Summary
- Adds `autoload -Uz add-zsh-hook` before its use on line 78 of `.zshrc`
- Without this, opening a new terminal produces `command not found: add-zsh-hook`
- Also required `brew install starship zsh-async` (already in Brewfile, just not installed)

## Test plan
- [x] Open a new terminal and verify no errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)