### PR TITLE
Share Claude Code slash commands across profiles

### DIFF
--- a/.claude-commands/daily-update.md
+++ b/.claude-commands/daily-update.md
@@ -1,0 +1,69 @@
+Generate Jess's daily status update for #proj-aiops by gathering context from Slack, Linear, and Notion, then creating any missing tickets before writing the final update.
+
+## Step 1: Load yesterday's plan
+
+Find and read the most recent file in `~/.claude/daily-updates/` to see what was planned. Compare against what actually got done.
+
+## Step 2: Gather data (run in parallel for speed)
+
+Use these MCP tools simultaneously:
+
+**Slack — read key channels (last 24h):**
+Calculate `oldest` as a Unix timestamp for 24 hours ago from now.
+- `slack_read_channel` for #human-jess (channel_id: `C084ANX70A1`, oldest: <24h ago>)
+- `slack_read_channel` for #proj-aiops (channel_id: `C0A1QJG57S9`, oldest: <24h ago>)
+- `slack_search_public` with query `from:<@U0852CJ7Q2U>` and `sort: timestamp` to find ALL messages I sent across all channels and DMs in the last 24h
+- For any messages with thread replies, use `slack_read_thread` to get full context
+
+**Linear — my active work:**
+- `list_issues` assigned to `me` in project `Automate Elicit` with state `started` (In Progress)
+- `list_issues` assigned to `me` in project `Automate Elicit` with state `unstarted` (Todo)
+- `list_issues` assigned to `me` in project `Automate Elicit` with state `completed` and updatedAt in last 24h
+
+**Notion — my recent edits:**
+- `notion-search` for pages I recently edited (filter by created_by or last_edited if possible)
+
+## Step 3: Propose new tickets FIRST
+
+Before writing the update, identify work from Slack/Notion conversations that isn't tracked in Linear yet. For each proposed ticket:
+- Present it clearly: **Title** — description, suggested priority, labels
+- Ask me if I want to create it, and what state it should be in (Done, In Progress, Todo)
+- If I say yes, use `save_issue` with team=Elicit, project=Automate Elicit, assignee=me
+- If the work is already done, also update the issue status to completed
+
+Wait for my responses before proceeding to Step 4.
+
+## Step 4: Write the update
+
+Now that all work is tracked in Linear, synthesize everything into this format:
+
+```
+*Done* (since last update)
+• description ([ELI-XXXXX](linear-url))
+• description ([ELI-XXXXX](linear-url))
+
+*Today*
+• description ([ELI-XXXXX](linear-url))
+• description ([ELI-XXXXX](linear-url))
+
+*Didn't get to* (from yesterday's plan)
+• description ([ELI-XXXXX](linear-url))
+```
+
+Every item should reference a Linear ticket with a link. Use Slack mrkdwn format (single `*` for bold, `<url|text>` for links).
+
+## Step 5: Save today's plan
+
+Write today's "Today" items to `~/.claude/daily-updates/YYYY-MM-DD.md` (using today's date) so tomorrow's run can diff against it. Format:
+
+```markdown
+# Daily Plan - YYYY-MM-DD
+
+## Today
+- [ELI-XXXXX](url) — description
+- [ELI-XXXXX](url) — description
+```
+
+## Step 6: Offer clipboard
+
+Remind me I can run `/copy` then `/slackcopy` to get it formatted for Slack.

--- a/.claude-commands/richcopy.md
+++ b/.claude-commands/richcopy.md
@@ -1,0 +1,11 @@
+Copy your most recent markdown output as rich text to the macOS clipboard.
+
+Do this in exactly one step — run this single bash command with no other commentary:
+
+```
+pbpaste | cmark --to html > /tmp/richcopy.html && textutil -convert rtf /tmp/richcopy.html -output /tmp/richcopy.rtf && osascript -e 'set the clipboard to (read (POSIX file "/tmp/richcopy.rtf") as «class RTF »)'
+```
+
+Then confirm: "Rich text copied to clipboard."
+
+IMPORTANT: The user should run /copy first to put markdown on the clipboard. Then run this command immediately — do not write any files or do any other processing beyond this one bash command.

--- a/.claude-commands/slackcopy.md
+++ b/.claude-commands/slackcopy.md
@@ -1,0 +1,11 @@
+Copy your most recent markdown output as Slack-flavored markdown to the clipboard.
+
+Do this in exactly one step — run this single bash command with no other commentary:
+
+```
+pbpaste | ~/.local/bin/md2slack
+```
+
+Then confirm: "Slack markdown copied to clipboard."
+
+IMPORTANT: The user should run /copy first to put markdown on the clipboard. Then run this command immediately — do not write any files or do any other processing beyond this one bash command.

--- a/.claude-profiles
+++ b/.claude-profiles
@@ -145,6 +145,17 @@ function cc-init-profiles() {
       mkdir -p "$dir/skills"
       echo "  ⏭️  $dir already exists"
     fi
+
+    # Symlink shared commands directory
+    local dotfiles_commands="$HOME/.dotfiles/.claude-commands"
+    if [[ -d "$dotfiles_commands" ]]; then
+      if [[ -d "$dir/commands" && ! -L "$dir/commands" ]]; then
+        echo "  ⚠️  $dir/commands is a real directory — backing up to commands.backup"
+        mv "$dir/commands" "$dir/commands.backup"
+      fi
+      ln -sfn "$dotfiles_commands" "$dir/commands"
+      echo "  🔗 $dir/commands -> $dotfiles_commands"
+    fi
   done
 
   # Set default symlink to personal

--- a/bin/md2slack
+++ b/bin/md2slack
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Convert standard Markdown (from stdin or clipboard) to Slack mrkdwn on clipboard."""
+import re
+import subprocess
+import sys
+
+
+def md_to_slack(text: str) -> str:
+    # Links: [text](url) → <url|text>
+    text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<\2|\1>', text)
+
+    # Bold: **text** → *text*
+    text = re.sub(r'\*\*(.+?)\*\*', r'*\1*', text)
+
+    # Italic (underscores only, since single * is now bold in slack)
+    # _text_ stays as _text_ (already slack-compatible)
+
+    # Headers: ### heading → *heading*
+    text = re.sub(r'^#{1,6}\s+(.+)$', r'*\1*', text, flags=re.MULTILINE)
+
+    # Bullet lists: - item → • item
+    text = re.sub(r'^- ', '• ', text, flags=re.MULTILINE)
+
+    # Inline code stays as backticks (compatible)
+    # Code blocks stay as triple backticks (compatible)
+
+    return text
+
+
+def main():
+    if not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        text = subprocess.check_output(['pbpaste'], text=True)
+
+    result = md_to_slack(text)
+
+    subprocess.run(['pbcopy'], input=result, text=True)
+    print("Slack markdown copied to clipboard.")
+
+
+if __name__ == '__main__':
+    main()

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,6 +42,11 @@ function createSymlinks() {
 		echo "  $dir -> $PWD/$dir"
 	done
 
+	# Symlink scripts to ~/.local/bin
+	mkdir -p "$HOME/.local/bin"
+	ln -sf "$PWD/bin/md2slack" "$HOME/.local/bin/md2slack"
+	echo "  bin/md2slack -> $PWD/bin/md2slack"
+
 	# Symlink starship config
 	mkdir -p "$HOME/.config"
 	if [[ -f "$HOME/.config/starship.toml" && ! -L "$HOME/.config/starship.toml" ]]; then


### PR DESCRIPTION
## Summary
- Add shared `.claude-commands/` directory with `richcopy` and `slackcopy` slash commands
- Bundle `md2slack` converter script in `bin/` and symlink to `~/.local/bin` during bootstrap
- Update `cc-init-profiles()` to symlink each profile's `commands/` to the shared directory

## Test plan
- [ ] Run `cc-init-profiles` and verify commands/ symlinks appear in all three profiles
- [ ] Switch profiles with `cce`/`ccp`/`ccst` and verify `/richcopy` and `/slackcopy` are available
- [ ] Run `bootstrap.sh` on a fresh setup and verify `~/.local/bin/md2slack` is symlinked

🤖 Generated with [Claude Code](https://claude.com/claude-code)